### PR TITLE
Added easy support for Spanish version in docker environment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM alpine:latest
-COPY tree-EN.sh /tree-EN.sh
+COPY tree-EN.sh tree-ES.sh tree-ENV_LANG.sh /
 RUN apk add --update ncurses bash
 ENV TERM=xterm-256color
-CMD ["bash","/tree-EN.sh"]
+CMD ["bash","/tree-ENV_LANG.sh"]

--- a/README.md
+++ b/README.md
@@ -30,7 +30,12 @@ Docker:
 
 ```
 docker pull sergiolepore/christbashtree:latest
+
+# English Version
 docker run -it sergiolepore/christbashtree:latest
+
+# Spanish Version
+docker run -it -e BASH_TREE_LANG=ES sergiolepore/christbashtree:latest
 ```
 
 Git clone and execute:

--- a/tree-ENV_LANG.sh
+++ b/tree-ENV_LANG.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+if [ $BASH_TREE_LANG = "ES" ]
+then
+  ./tree-ES.sh
+else
+  ./tree-EN.sh
+fi


### PR DESCRIPTION
I've enjoyed running this tree in my terminal last year and noticed you added Docker support this year.  I made a little change and made it easy to display the Spanish message in docker also